### PR TITLE
Pip project name change to avoid collisions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setuptools.setup(
-    name='cached_property',
+    name='cached_property_bel',
     version='1.0.1',
     author='Justus Schwabedal',
     author_email='jschwabedal@belco.tech',


### PR DESCRIPTION
Just changes the name of the pip package from `cached-property` to `cached-property-bel` so we can upload the project to pip.

We may want to consider renaming the repository for consistency's sake - but that's a bridge for another day methinks.